### PR TITLE
Getting cluster prod-ready

### DIFF
--- a/inputs.tf
+++ b/inputs.tf
@@ -47,6 +47,11 @@ variable "subdomain" {
   default     = null
 }
 
+variable "api_cidr_block" {
+  description = "CIDR Block of Web API that can access IPFS HTTP API"
+  type        = string
+}
+
 variable "acme_email" {
   description = "Email address where Let's Encrypt can contact you regarding ACME certificates."
   type        = string

--- a/ipfs-cluster-aws-region/inputs.tf
+++ b/ipfs-cluster-aws-region/inputs.tf
@@ -36,3 +36,8 @@ variable "volume_size" {
   type        = number
   default     = 50
 }
+
+variable "api_cidr_block" {
+  description = "CIDR Block of Web API that can access IPFS HTTP API"
+  type        = string
+}

--- a/ipfs-cluster-aws-region/main.tf
+++ b/ipfs-cluster-aws-region/main.tf
@@ -87,6 +87,22 @@ resource "aws_security_group" "this" {
   }
 
   ingress {
+    description      = "Allow inbound IPFS HTTP requests from Web API"
+    from_port        = 5001
+    to_port          = 5001
+    protocol         = "tcp"
+    cidr_blocks      = ["172.31.0.0/16"]
+  }
+
+  ingress {
+    description      = "Allow inbound IPFS Cluster HTTP requests from Web API"
+    from_port        = 9095
+    to_port          = 9095
+    protocol         = "tcp"
+    cidr_blocks      = ["172.31.0.0/16"]
+  }
+
+  ingress {
     description = "Allow inbound ICMP"
     protocol    = "icmp"
     from_port   = -1

--- a/ipfs-cluster-aws-region/main.tf
+++ b/ipfs-cluster-aws-region/main.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "this" {
     from_port        = 5001
     to_port          = 5001
     protocol         = "tcp"
-    cidr_blocks      = ["172.31.0.0/16"]
+    cidr_blocks      = [var.api_cidr_block]
   }
 
   ingress {
@@ -99,7 +99,7 @@ resource "aws_security_group" "this" {
     from_port        = 9095
     to_port          = 9095
     protocol         = "tcp"
-    cidr_blocks      = ["172.31.0.0/16"]
+    cidr_blocks      = [var.api_cidr_block]
   }
 
   ingress {

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,9 @@ resource "acme_registration" "this" {
 resource "acme_certificate" "this" {
   account_key_pem = acme_registration.this.account_key_pem
   common_name     = local.fqdn
-  # subject_alternative_names = []
+  subject_alternative_names = [
+    for n in local.nodes : n.node_fqdn
+  ]
   recursive_nameservers = data.aws_route53_zone.this.name_servers
 
   dns_challenge {

--- a/nixos/ipfs-cluster-aws.nix
+++ b/nixos/ipfs-cluster-aws.nix
@@ -55,6 +55,8 @@ in
           443 # IPFS gateway https
           4001 # IPFS swarm TCPACME
           4003 # IPFS swarm Secure Websocket
+          5001 # IPFS HTTP API
+          9095 # IPFS Cluster HTTP API
           9096 # IPFS Cluster swarm
         ];
         allowedUDPPorts = [
@@ -164,7 +166,7 @@ in
 
       extraConfig = {
         Datastore = {
-          StorageMax = "100GB";
+          StorageMax = "10000GB";
           Spec = {
             type = "mount";
             mounts = [

--- a/nixos/ipfs-cluster-aws.nix
+++ b/nixos/ipfs-cluster-aws.nix
@@ -155,6 +155,8 @@ in
       enable = true;
       emptyRepo = true;
 
+      apiAddress = "/ip4/0.0.0.0/tcp/5001";
+
       swarmAddress = [
         "/ip4/0.0.0.0/tcp/4001"
         "/ip6/::/tcp/4001"

--- a/nixos/ipfs-cluster-aws.nix
+++ b/nixos/ipfs-cluster-aws.nix
@@ -54,6 +54,7 @@ in
           80 # HTTP ACME and redirect to :443
           443 # IPFS gateway https
           4001 # IPFS swarm TCPACME
+          4002 # IPFS swarm Websocket
           4003 # IPFS swarm Secure Websocket
           5001 # IPFS HTTP API
           9095 # IPFS Cluster HTTP API
@@ -162,7 +163,7 @@ in
         "/ip6/::/tcp/4001"
         "/ip4/0.0.0.0/udp/4001/quic"
         "/ip6/::/udp/4001/quic"
-        "/ip4/127.0.0.1/tcp/4002/ws"
+        "/ip4/0.0.0.0/tcp/4002/ws"
         "/ip6/::1/tcp/4002/ws"
       ];
 

--- a/regions.tf
+++ b/regions.tf
@@ -175,25 +175,27 @@ provider "aws" {
 
 
 module "ipfs-cluster-aws-region-us-east-1" {
-  providers     = { aws = aws.us-east-1 }
-  nodes         = local.region_nodes_map["us-east-1"]
-  region_fqdn   = local.region_map["us-east-1"].region_fqdn
-  tags          = merge(local.tags, { Name = local.region_map["us-east-1"].region_prefix })
-  source        = "./ipfs-cluster-aws-region"
-  public_key    = local.public_key
-  instance_type = var.instance_type
-  volume_size   = var.volume_size
-  fqdn          = local.fqdn
+  providers      = { aws = aws.us-east-1 }
+  nodes          = local.region_nodes_map["us-east-1"]
+  region_fqdn    = local.region_map["us-east-1"].region_fqdn
+  tags           = merge(local.tags, { Name = local.region_map["us-east-1"].region_prefix })
+  source         = "./ipfs-cluster-aws-region"
+  public_key     = local.public_key
+  instance_type  = var.instance_type
+  volume_size    = var.volume_size
+  fqdn           = local.fqdn
+  api_cidr_block = var.api_cidr_block
 }
 
 module "ipfs-cluster-aws-region-eu-north-1" {
-  providers     = { aws = aws.eu-north-1 }
-  nodes         = local.region_nodes_map["eu-north-1"]
-  region_fqdn   = local.region_map["eu-north-1"].region_fqdn
-  tags          = merge(local.tags, { Name = local.region_map["eu-north-1"].region_prefix })
-  source        = "./ipfs-cluster-aws-region"
-  instance_type = var.instance_type
-  public_key    = local.public_key
-  volume_size   = var.volume_size
-  fqdn          = local.fqdn
+  providers      = { aws = aws.eu-north-1 }
+  nodes          = local.region_nodes_map["eu-north-1"]
+  region_fqdn    = local.region_map["eu-north-1"].region_fqdn
+  tags           = merge(local.tags, { Name = local.region_map["eu-north-1"].region_prefix })
+  source         = "./ipfs-cluster-aws-region"
+  instance_type  = var.instance_type
+  public_key     = local.public_key
+  volume_size    = var.volume_size
+  fqdn           = local.fqdn
+  api_cidr_block = var.api_cidr_block
 }


### PR DESCRIPTION
Included are several updates to the terraform/nix setup for the cluster:
- an additional variable for the API's CIDR block so that the cluster's security group allows to hit ports 5001/9095 (ipfs http api & cluster http api respectively)
- expose ports 4002 (websockets) publicly & ports 5001/9095 to the web api as mentioned above^^
- run ipfs http api on `0.0.0.0` instead of `127.0.0.1` so that the web api can access it
- increase storage max size from 100GB to 10TB (increase further??)
- add individual node domains to SSL certificate for `wss` connections from the browser