### PR TITLE
Auto-renewable certs through acme/lets encrypt

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -310,17 +310,12 @@ data "null_data_source" "configuration" {
 
       networking.hostName = "${local.nodes[count.index].node_prefix}";
 
-      security.acme.email = "${var.acme_email}";
-
-      services.ipfs-cluster.bootstrapPeers = [
-        ${join(" ", [for i in range(length(local.nodes)) : "\"/ip4/${local.node_ips[i]}/tcp/9096/ipfs/${shell_script.node_identity[i].output["id"]}\"" if i != count.index])}
-      ];
-
       services.ipfs-cluster-aws = {
         enable = true;
         region = "${local.nodes[count.index].region_name}";
         bucket = "${local.bucket_names[count.index]}";
         domain = "${var.domain}";
+        fqdn   = "${local.nodes[count.index].node_fqdn";
       };
     }
   EOT

--- a/nixos/ipfs-cluster-aws.nix
+++ b/nixos/ipfs-cluster-aws.nix
@@ -32,6 +32,11 @@ in
       type = str;
       description = "Full domain for node";
     };
+
+    crons = mkOption {
+      type = listOf str;
+      description = "List of cronjobs";
+    };
   };
   
   config = mkIf cfg.enable {
@@ -95,14 +100,7 @@ in
 
     services.cron = {
       enable = true;
-      systemCronJobs = [
-        "0 9 * * *      root    systemctl restart ipfs"
-        "* * * * *      root    ipfs swarm connect /dns4/production-ipfs-cluster-us-east-1-node0.runfission.com/tcp/4001/p2p/12D3KooWFSAbpiAeKHnVyqMqrdvAtu8C3veePHi36bZGNM2qv42q"
-        "* * * * *      root    ipfs swarm connect /dns4/production-ipfs-cluster-us-east-1-node1.runfission.com/tcp/4001/p2p/12D3KooWNntMEXRUa2dNgkQsVgzao6zGSYxm1oAs83YtRy6uBuxv"
-        "* * * * *      root    ipfs swarm connect /dns4/production-ipfs-cluster-us-east-1-node2.runfission.com/tcp/4001/p2p/12D3KooWQ2hL9NschcJ1Suqa1TybJc2ZaacqoQMBT3ziFC7Ye2BZ"
-        "* * * * *      root    ipfs swarm connect /dns4/production-ipfs-cluster-eu-north-1-node0.runfission.com/tcp/4001/p2p/12D3KooWDTUTdVJfW7Rwb6kKhceEwevTatPXnavPwkfZp2A6r1Fn"
-        "* * * * *      root    ipfs swarm connect /dns4/production-ipfs-cluster-eu-north-1-node1.runfission.com/tcp/4001/p2p/12D3KooWRwbRrSN2cPAKz4yt1vxBFdh53CpgWjSFK5hZPkzHHz5h"
-      ];
+      systemCronJobs = cfg.crons;
     };
 
     systemd.services.ipfs-init = {

--- a/nixos/ipfs-cluster-aws.nix
+++ b/nixos/ipfs-cluster-aws.nix
@@ -27,6 +27,11 @@ in
       type = str;
       description = "Root domain for TLS ACME Certs";
     };
+
+    fqdn = mkOption {
+      type = str;
+      description = "Full domain for node";
+    };
   };
   
   config = mkIf cfg.enable {
@@ -57,6 +62,7 @@ in
     };
 
     security.acme.acceptTerms = true;
+    security.acme.email = "support@fission.codes";
 
     services.openssh.enable = true;
 
@@ -70,43 +76,9 @@ in
         server_names_hash_bucket_size 128;
       '';
 
-      virtualHosts.ipfs-gateway = {
-        serverName = "${cfg.domain}";
-        serverAliases = ["*.${cfg.domain}"];
-        forceSSL = true;
-        sslCertificate = "/var/lib/ssl/cert";
-        sslCertificateKey = "/var/lib/ssl/key";
-
-        locations."/" = {
-          proxyPass = "http://127.0.0.1:8080";
-          proxyWebsockets = true;
-        };
-      };
-
-      virtualHosts.ipfs-gateway-https = {
-        serverName = "${cfg.domain}";
-        serverAliases = ["*.${cfg.domain}"];
-        onlySSL = true;
-        sslCertificate = "/var/lib/ssl/cert";
-        sslCertificateKey = "/var/lib/ssl/key";
-
-        listen = [
-          { addr = "0.0.0.0"; port = 443; ssl = true; }
-          { addr = "[::]";    port = 443; ssl = true; }
-        ];
-
-        locations."/" = {
-          proxyPass = "http://127.0.0.1:8080";
-          proxyWebsockets = true;
-        };
-      };
-
-      virtualHosts.ipfs-swarm-wss = {
-        serverName = "${cfg.domain}";
-        serverAliases = ["*.${cfg.domain}"];
-        onlySSL = true;
-        sslCertificate = "/var/lib/ssl/cert";
-        sslCertificateKey = "/var/lib/ssl/key";
+      virtualHosts."${cfg.fqdn}" = {
+        addSSL = true;
+        enableACME = true;
 
         listen = [
           { addr = "0.0.0.0"; port = 4003; ssl = true; }
@@ -116,6 +88,7 @@ in
         locations."/" = {
           proxyPass = "http://127.0.0.1:4002";
           proxyWebsockets = true;
+          root = "/var/www";
         };
       };
     };

--- a/nixos/ipfs-cluster-aws.nix
+++ b/nixos/ipfs-cluster-aws.nix
@@ -81,6 +81,17 @@ in
         server_names_hash_bucket_size 128;
       '';
 
+      # Even though we don't use port 80/443, we leave this in the nginx config to help out Let's Encrypt
+      virtualHosts.root = {
+        addSSL = true;
+        enableACME = true;
+        serverName = "${cfg.fqdn}";
+
+        locations."/" = {
+          root = "/var/www";
+        };
+      };
+
       virtualHosts."${cfg.fqdn}" = {
         addSSL = true;
         enableACME = true;


### PR DESCRIPTION
## Problem
ACME certs expire. We went offscript with terraform so just can't run a new deploy

## Solution
Move ACME certs to the nix config. Let's Encrypt should be able to auto-renew them

### Also included
- remove some leftover references to `ipfs-cluster`
- move cron jobs list to the root config, so that every node as the same `ipfs-cluster-aws.nix` file and we can just copy/paste changes
---
## Steps for updating nodes
- add write permission to root config: `sudo chmod +w /etc/nixos/configuration.nix`
- remove `security.acme.email` & `services.ipfs-cluster.bootstrapPeers` value
- add `fqdn` config variable to `services.ipfs-cluster-aws` with full domain name for node
- add `crons` config variable with list of cronjobs (copy over from current `ipfs-cluster-aws/nixos/ipfs-cluster-aws.nix` file)

It should look something like: 
```
{
  imports = [ /root/ipfs-cluster-aws/nixos/ipfs-cluster-aws.nix ];

  networking.hostName = "staging-ipfs-cluster-us-east-1-node0";

  services.ipfs-cluster-aws = {
    enable = true;
    region = "us-east-1";
    bucket = "staging-ipfs-cluster-us-east-1";
    domain = "runfission.net";
    fqdn   = "staging-ipfs-clsuter-us-east-1-node0.runfission.net";
    crons  = [
      "0 3 * * *      root    systemctl restart ipfs"
      "* * * * *      root    ipfs swarm connect /dns4/staging-ipfs-cluster-us-east-1-node1.runfission.net/tcp/4001/p2p/12D3KooWGBhBMi3FQqLSnsTSQJeGeJoqABkwoKKHfzC8QP2s5oxr"
      "* * * * *      root    ipfs swarm connect /dns4/staging-ipfs-cluster-us-east-1-node0.runfission.net/tcp/4001/p2p/12D3KooWDX4mGcThxuWHqySi8awYXgLDTEhNSjp1BY9ToWbBh8q5"
    ];
  };
}
```
- remove `ipfs-cluster-aws/nixos/ipfs-cluster.nix`
- update `ipfs-cluster-aws/nixos/ipfs-cluster-aws.nix` to the current config