### PR TITLE
Fix CORS error on API reqs

### DIFF
--- a/nixos/ipfs-cluster-aws.nix
+++ b/nixos/ipfs-cluster-aws.nix
@@ -175,6 +175,11 @@ in
       ];
 
       extraConfig = {
+        API = {
+          HTTPHeaders = {
+            Access-Control-Allow-Origin = ["*"];
+          };
+        };
         Datastore = {
           StorageMax = "10000GB";
           Spec = {


### PR DESCRIPTION
## Problem
CORS errors on API requests. Some requests to the gateway (such as `ls`) get forwarded to the API which adds headers to it. So some gateway accessible routes will have CORS errors, even though the gateway as the `Access-Control-Allow-Origin: *` header set.

## Solution
Set the `Access-Control-Allow-Origin: *` header for HTTP API requests as well.