### PR TITLE
Repo migrations

### DIFF
--- a/nix/ipfs-migrator.nix
+++ b/nix/ipfs-migrator.nix
@@ -1,24 +1,25 @@
 { buildGoModule, lib }:
 
-buildGoModule rec {
-  pname = "ipfs-migrator";
+let
   version = "1.7.1";
-  rev = "v${version}";
+  pkgs = import ./sources.nix;
+in
+  buildGoModule {
+    inherit version;
 
-  src = (import ./sources.nix).ipfs-migrator;
+    pname = "ipfs-migrator";
+    rev = "v${version}";
 
-  vendorSha256 = null;
+    src = pkgs.ipfs-migrator;
+    vendorSha256 = null;
+    doCheck = false;
+    subPackages = [ "." ];
 
-  doCheck = false;
-
-  subPackages = [ "." ];
-
-  meta = with lib; {
-    description = "Migrations for the filesystem repository of ipfs clients";
-    homepage = "https://ipfs.io/";
-    license = licenses.mit;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ elitak ];
-  };
+    meta = {
+      description = "Migrations for the filesystem repository of ipfs clients";
+      homepage = "https://ipfs.io/";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+      maintainers =  [ lib.maintainers.elitak ];
+    };
 }
-

--- a/nix/ipfs-migrator.nix
+++ b/nix/ipfs-migrator.nix
@@ -1,0 +1,24 @@
+{ buildGoModule, lib }:
+
+buildGoModule rec {
+  pname = "ipfs-migrator";
+  version = "1.7.1";
+  rev = "v${version}";
+
+  src = (import ./sources.nix).ipfs-migrator;
+
+  vendorSha256 = null;
+
+  doCheck = false;
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Migrations for the filesystem repository of ipfs clients";
+    homepage = "https://ipfs.io/";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ elitak ];
+  };
+}
+

--- a/nix/ipfs.nix
+++ b/nix/ipfs.nix
@@ -2,22 +2,27 @@
 
 { stdenv, buildGoModule, fetchurl, nixosTests }:
 
-buildGoModule rec {
-  pname = "ipfs";
+let
   version = "0.8.0";
-  rev = "v${version}";
+  pkgs = import ./sources.nix;
+in 
+  buildGoModule {
+    inherit version;
 
-  src = (import ./sources.nix).ipfs;
+    pname = "ipfs";
+    rev = "v${version}";
 
-  subPackages = [ "cmd/ipfs" ];
+    src = pkgs.ipfs;
 
-  vendorSha256 = "1qifcp1mv2fim5csn8g5vdjm88i0sa4n4qzihylli48593mmj3zq";
+    subPackages = [ "cmd/ipfs" ];
 
-  postInstall = ''
-    install --mode=444 -D misc/systemd/ipfs.service $out/etc/systemd/system/ipfs.service
-    install --mode=444 -D misc/systemd/ipfs-api.socket $out/etc/systemd/system/ipfs-api.socket
-    install --mode=444 -D misc/systemd/ipfs-gateway.socket $out/etc/systemd/system/ipfs-gateway.socket
-    substituteInPlace $out/etc/systemd/system/ipfs.service \
-      --replace /usr/bin/ipfs $out/bin/ipfs
-  '';
-}
+    vendorSha256 = "1qifcp1mv2fim5csn8g5vdjm88i0sa4n4qzihylli48593mmj3zq";
+
+    postInstall = ''
+      install --mode=444 -D misc/systemd/ipfs.service $out/etc/systemd/system/ipfs.service
+      install --mode=444 -D misc/systemd/ipfs-api.socket $out/etc/systemd/system/ipfs-api.socket
+      install --mode=444 -D misc/systemd/ipfs-gateway.socket $out/etc/systemd/system/ipfs-gateway.socket
+      substituteInPlace $out/etc/systemd/system/ipfs.service \
+        --replace /usr/bin/ipfs $out/bin/ipfs
+    '';
+  }

--- a/nix/ipfs.nix
+++ b/nix/ipfs.nix
@@ -4,14 +4,14 @@
 
 buildGoModule rec {
   pname = "ipfs";
-  version = "0.7.0";
+  version = "0.8.0";
   rev = "v${version}";
 
   src = (import ./sources.nix).ipfs;
 
   subPackages = [ "cmd/ipfs" ];
 
-  vendorSha256 = "1493a01ckgjmyxr88fk39la5fask4plnl0lajgixhyjzpr6p5hss";
+  vendorSha256 = "1qifcp1mv2fim5csn8g5vdjm88i0sa4n4qzihylli48593mmj3zq";
 
   postInstall = ''
     install --mode=444 -D misc/systemd/ipfs.service $out/etc/systemd/system/ipfs.service

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -6,5 +6,6 @@ in
 {
   ipfs-key = self.callPackage ./ipfs-key.nix {};
   ipfs = nixpkgs-unstable.callPackage ./ipfs.nix {};
+  ipfs-migrator = nixpkgs-unstable.callPackage ./ipfs-migrator.nix {};
   writeTurtleBin = self.callPackage ./writeTurtleBin.nix { inherit (self.writers) writeHaskellBin; };
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,50 +1,50 @@
 {
-    "ipfs": {
-        "branch": "with-s3",
-        "description": "IPFS implementation in Go",
-        "homepage": "https://ipfs.io",
-        "owner": "fission-suite",
-        "repo": "go-ipfs",
-        "rev": "391e29d7f6f64300055d88c9385222f7619525ed",
-        "sha256": "066a0wcjvfg9m2a3kz4kz1vbr1xnr812fq57417d7hcjp5ca2x83",
-        "type": "tarball",
-        "url": "https://github.com/fission-suite/go-ipfs/archive/391e29d7f6f64300055d88c9385222f7619525ed.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "ipfs-key": {
-        "branch": "master",
-        "description": "A program to generate ipfs private keys",
-        "homepage": null,
-        "owner": "fission-suite",
-        "repo": "ipfs-key",
-        "rev": "9171388a3ecfc41966e13a9a56745b3b2eda0463",
-        "sha256": "195h3n38b9cnq3r5fip2nwkqwnhws45s8rc17j92sa3snf8nxygc",
-        "type": "tarball",
-        "url": "https://github.com/fission-suite/ipfs-key/archive/9171388a3ecfc41966e13a9a56745b3b2eda0463.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "niv": {
-        "branch": "master",
-        "description": "Easy dependency management for Nix projects",
-        "homepage": "https://github.com/nmattia/niv",
-        "owner": "nmattia",
-        "repo": "niv",
-        "rev": "9d35b9e4837ab88517210b1701127612c260eccf",
-        "sha256": "0q50xhnm8g2yfyakrh0nly4swyygxpi0a8cb9gp65wcakcgvzvdh",
-        "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/9d35b9e4837ab88517210b1701127612c260eccf.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs": {
-        "branch": "nixpkgs-unstable",
-        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
-        "homepage": "https://github.com/NixOS/nixpkgs",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "cfed29bfcb28259376713005d176a6f82951014a",
-        "sha256": "034m892hxygminkj326y7l3bp4xhx0v154jcmla7wdfqd23dk5xm",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cfed29bfcb28259376713005d176a6f82951014a.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    }
+  "ipfs": {
+      "branch": "with-s3",
+      "description": "IPFS implementation in Go",
+      "homepage": "https://ipfs.io",
+      "owner": "fission-suite",
+      "repo": "go-ipfs",
+      "rev": "72c52d0ea145d43124be72c5f1367592320dc0ea",
+      "sha256": "047fr3ahpw8lnj1mjkrkhf1b2vw9687yks45bwrfqb0kaan0045k",
+      "type": "tarball",
+      "url": "https://github.com/fission-suite/go-ipfs/archive/72c52d0ea145d43124be72c5f1367592320dc0ea.tar.gz",
+      "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
+  "ipfs-key": {
+      "branch": "master",
+      "description": "A program to generate ipfs private keys",
+      "homepage": null,
+      "owner": "brainrape",
+      "repo": "ipfs-key",
+      "rev": "9171388a3ecfc41966e13a9a56745b3b2eda0463",
+      "sha256": "195h3n38b9cnq3r5fip2nwkqwnhws45s8rc17j92sa3snf8nxygc",
+      "type": "tarball",
+      "url": "https://github.com/brainrape/ipfs-key/archive/9171388a3ecfc41966e13a9a56745b3b2eda0463.tar.gz",
+      "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
+  "niv": {
+      "branch": "master",
+      "description": "Easy dependency management for Nix projects",
+      "homepage": "https://github.com/nmattia/niv",
+      "owner": "nmattia",
+      "repo": "niv",
+      "rev": "9d35b9e4837ab88517210b1701127612c260eccf",
+      "sha256": "0q50xhnm8g2yfyakrh0nly4swyygxpi0a8cb9gp65wcakcgvzvdh",
+      "type": "tarball",
+      "url": "https://github.com/nmattia/niv/archive/9d35b9e4837ab88517210b1701127612c260eccf.tar.gz",
+      "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
+  "nixpkgs": {
+      "branch": "nixpkgs-unstable",
+      "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
+      "homepage": "https://github.com/NixOS/nixpkgs",
+      "owner": "NixOS",
+      "repo": "nixpkgs",
+      "rev": "d9448c95c5d557d0b2e8bfe13e8865e4b1e3943f",
+      "sha256": "0bs2pjd9ns21m98an5bms49l20kk43gby9h1f5j2n5xk9ykpsr29",
+      "type": "tarball",
+      "url": "https://github.com/NixOS/nixpkgs/archive/d9448c95c5d557d0b2e8bfe13e8865e4b1e3943f.tar.gz",
+      "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -15,12 +15,24 @@
       "branch": "master",
       "description": "A program to generate ipfs private keys",
       "homepage": null,
-      "owner": "brainrape",
+      "owner": "fission-suite",
       "repo": "ipfs-key",
       "rev": "9171388a3ecfc41966e13a9a56745b3b2eda0463",
       "sha256": "195h3n38b9cnq3r5fip2nwkqwnhws45s8rc17j92sa3snf8nxygc",
       "type": "tarball",
-      "url": "https://github.com/brainrape/ipfs-key/archive/9171388a3ecfc41966e13a9a56745b3b2eda0463.tar.gz",
+      "url": "https://github.com/fission-suite/ipfs-key/archive/9171388a3ecfc41966e13a9a56745b3b2eda0463.tar.gz",
+      "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
+  "ipfs-migrator": {
+      "branch": "with-s3-v1",
+      "description": "Migrations for the filesystem repository of ipfs clients",
+      "homepage": "",
+      "owner": "fission-suite",
+      "repo": "fs-repo-migrations",
+      "rev": "8fe6cf6de0861027d36856c4d6e69a885c5aafc2",
+      "sha256": "0xz0i1rlglmv1dzx6fziapikwzcaqph1s3xbhswrhc672yyabjrd",
+      "type": "tarball",
+      "url": "https://github.com/fission-suite/fs-repo-migrations/archive/8fe6cf6de0861027d36856c4d6e69a885c5aafc2.tar.gz",
       "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
   },
   "niv": {
@@ -29,10 +41,10 @@
       "homepage": "https://github.com/nmattia/niv",
       "owner": "nmattia",
       "repo": "niv",
-      "rev": "9d35b9e4837ab88517210b1701127612c260eccf",
-      "sha256": "0q50xhnm8g2yfyakrh0nly4swyygxpi0a8cb9gp65wcakcgvzvdh",
+      "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
+      "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
       "type": "tarball",
-      "url": "https://github.com/nmattia/niv/archive/9d35b9e4837ab88517210b1701127612c260eccf.tar.gz",
+      "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
       "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
   },
   "nixpkgs": {
@@ -41,10 +53,10 @@
       "homepage": "https://github.com/NixOS/nixpkgs",
       "owner": "NixOS",
       "repo": "nixpkgs",
-      "rev": "d9448c95c5d557d0b2e8bfe13e8865e4b1e3943f",
-      "sha256": "0bs2pjd9ns21m98an5bms49l20kk43gby9h1f5j2n5xk9ykpsr29",
+      "rev": "267761cf44498f9e1aa81dbdb92d77d5873dd9f6",
+      "sha256": "08k5nm9535wmc62hb2hjys6kfvd84g9765kdcslni1bb1qn98f7h",
       "type": "tarball",
-      "url": "https://github.com/NixOS/nixpkgs/archive/d9448c95c5d557d0b2e8bfe13e8865e4b1e3943f.tar.gz",
+      "url": "https://github.com/NixOS/nixpkgs/archive/267761cf44498f9e1aa81dbdb92d77d5873dd9f6.tar.gz",
       "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
   }
 }

--- a/system-nixos/configuration.nix
+++ b/system-nixos/configuration.nix
@@ -1,0 +1,25 @@
+# This is the system NixOS config which sits at /etc/nixos/configuration.nix
+# The variables in this config need to be updated per-node
+let
+  custom = import /root/ipfs-cluster-aws/nix/default.nix {};
+in
+{
+  imports = [ /root/ipfs-cluster-aws/nixos/ipfs-cluster-aws.nix ];
+
+  environment.systemPackages = [ custom.ipfs-migrator ];
+
+  networking.hostName = "staging-ipfs-cluster-us-east-1-node1";
+
+  services.ipfs-cluster-aws = {
+    enable = true;
+    region = "us-east-1";
+    bucket = "staging-ipfs-cluster-us-east-1";
+    domain = "runfission.net";
+    fqdn  = "staging-ipfs-cluster-us-east-1-node1.runfission.net";
+    crons = [
+        "15 9 * * *     root    systemctl restart ipfs"
+        "* * * * *      root    ipfs swarm connect /dns4/staging-ipfs-cluster-us-east-1-node0.runfission.net/tcp/4001/p2p/12D3KooWDX4mGcThxuWHqySi8awYXgLDTEhNSjp1BY9ToWbBh8q5"
+        "* * * * *      root    ipfs swarm connect /dns4/staging-ipfs-cluster-eu-north-1-node0.runfission.net/tcp/4001/p2p/12D3KooWLYqhKbUa9LSdzPZrKPSePipXgVRrHqzr8Uw5cmqqvXuC"
+    ];
+  };
+}


### PR DESCRIPTION
## Problem
We want to upgrade ipfs to 0.8

## Solution
- Build the s3 plugin into ipfs at v0.8
- Build the s3 plugin into `ipfs-migrator` at v1.7.1

---
## Steps to deploy to a node
- Update the following files at `ipfs-cluster-aws/nix` to the most current version (in this repo)
  - ipfs-migrator.nix
  - ipfs.nix
  - overlay.nix
  - sources.json
- update `/etc/nixos/configuration.nix` to match the system config
  - add the `custom` import
  - add `custom.ipfs-migrator` to `systemPackages`
- run `nixos-rebuild switch`
- ^^ this _will_ fail since the repo isn't migrated yet
- run `IPFS_PATH=/var/lib/ipfs fs-repo-migrations`
- run another `nixos-rebuild switch` 